### PR TITLE
Disable g2.testnets auto update

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -61,11 +61,6 @@ jobs:
             --arg key .substrate_node_runner.node.image \
             --arg value ${DOCKER_IMAGE_TAG} \
             '{file: $file, key: $key, value: $value}' >> /tmp/changes.json
-          jq -n \
-            --arg file playbooks/koi_nodes/host_vars/g2.testnets \
-            --arg key .substrate_node_runner.node.image \
-            --arg value ${DOCKER_IMAGE_TAG} \
-            '{file: $file, key: $key, value: $value}' >> /tmp/changes.json
 
           MULTI_CHANGES=$(jq -crs '.' < /tmp/changes.json)
           GITHUB_TOKEN=${{ secrets.GH_TKN_DARWINIA }} gh workflow run \


### PR DESCRIPTION
g2.testnets will run force debug node, https://github.com/darwinia-network/devops/blob/f38f60fe1e008e1867b9eaaf7a3a5d62fd06d483/.github/workflows/trigger-tracing-node.yml#L70-L74 so there we can remove it.